### PR TITLE
Ignore duplicate editor-documents when importing

### DIFF
--- a/.changeset/wet-cheetahs-watch.md
+++ b/.changeset/wet-cheetahs-watch.md
@@ -1,0 +1,5 @@
+---
+'@lblod/template-export-service': patch
+---
+
+Add workaround for duplicate editor-documents when importing templates

--- a/src/actions/export.ts
+++ b/src/actions/export.ts
@@ -27,7 +27,7 @@ export async function collectResourcesToExport({
     documentContainerUris.map(findDocumentContainerOrFail)
   );
   const editorDocuments = await Promise.all(
-    documentContainers.map(findCurrentDocumentContainerVersion)
+    documentContainers.map((dc) => findCurrentDocumentContainerVersion(dc))
   );
   const snippetLists: SnippetList[] = [];
   const snippets: Snippet[] = [];

--- a/src/actions/import.ts
+++ b/src/actions/import.ts
@@ -175,7 +175,10 @@ async function importDocumentContainers(serialization: Serialization) {
       await persistEditorDocument(currentVersion);
       const documentContainerInDB = await findDocumentContainer(container.uri);
       const currentVersionInDB = documentContainerInDB
-        ? await findCurrentVersion_DocumentContainer(documentContainerInDB)
+        ? await findCurrentVersion_DocumentContainer(
+            documentContainerInDB,
+            true
+          )
         : null;
       if (
         !currentVersionInDB ||

--- a/src/actions/import.ts
+++ b/src/actions/import.ts
@@ -175,10 +175,9 @@ async function importDocumentContainers(serialization: Serialization) {
       await persistEditorDocument(currentVersion);
       const documentContainerInDB = await findDocumentContainer(container.uri);
       const currentVersionInDB = documentContainerInDB
-        ? await findCurrentVersion_DocumentContainer(
-            documentContainerInDB,
-            true
-          )
+        ? await findCurrentVersion_DocumentContainer(documentContainerInDB, [
+            'uri',
+          ])
         : null;
       if (
         !currentVersionInDB ||

--- a/src/db/document-container.ts
+++ b/src/db/document-container.ts
@@ -131,6 +131,12 @@ export async function createDocumentContainer(
   return container;
 }
 
-export async function findCurrentVersion(documentContainer: DocumentContainer) {
-  return findEditorDocumentOrFail(documentContainer.currentVersionUri);
+export async function findCurrentVersion(
+  documentContainer: DocumentContainer,
+  acceptMultiple?: boolean
+) {
+  return findEditorDocumentOrFail(
+    documentContainer.currentVersionUri,
+    acceptMultiple
+  );
 }

--- a/src/db/document-container.ts
+++ b/src/db/document-container.ts
@@ -9,6 +9,7 @@ import { objectify } from '../utils/sparql';
 import { Optional } from '../utils/types';
 import { findEditorDocumentOrFail } from './editor-document';
 import { expect } from '../utils/option';
+import { EditorDocument } from '../schemas/editor-document';
 
 export async function findDocumentContainer(uri: string) {
   const response = await query<DocumentContainer>(/* sparql */ `
@@ -133,10 +134,10 @@ export async function createDocumentContainer(
 
 export async function findCurrentVersion(
   documentContainer: DocumentContainer,
-  acceptMultiple?: boolean
+  assertUniquenessOf?: (keyof EditorDocument)[]
 ) {
   return findEditorDocumentOrFail(
     documentContainer.currentVersionUri,
-    acceptMultiple
+    assertUniquenessOf
   );
 }

--- a/src/db/editor-document.ts
+++ b/src/db/editor-document.ts
@@ -19,7 +19,9 @@ import { expect } from '../utils/option';
 
 export async function findEditorDocument(
   uri: string,
-  acceptMultiple?: boolean
+  /** Which fields can there not be multiple values for, errors if multiples are found. Defaults to
+   * all fields if nothing passed */
+  assertUniquenessOf?: (keyof EditorDocument)[]
 ) {
   const response = await query<EditorDocument>(/* sparql */ `
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -57,26 +59,35 @@ export async function findEditorDocument(
 
         FILTER(?uri = ${sparqlEscapeUri(uri)})
       }`);
-  if (!response.results.bindings.length) {
+  const bindings = response.results.bindings;
+  if (!bindings.length) {
     return null;
   }
-  if (!acceptMultiple && response.results.bindings.length > 1) {
-    throw new AppError(
-      StatusCodes.CONFLICT,
-      `Expected to only find a single result when querying EditorDocument ${uri} `
-    );
+  if (bindings.length > 1) {
+    if (
+      !assertUniquenessOf ||
+      assertUniquenessOf.some((uniqueField) => {
+        const values = new Set(
+          bindings.map((bind) => bind[uniqueField]?.value)
+        );
+        return values.size > 1;
+      })
+    ) {
+      throw new AppError(
+        StatusCodes.CONFLICT,
+        `Expected to only find a single result when querying EditorDocument ${uri} `
+      );
+    }
   }
-  const editorDocument: EditorDocumentInput = objectify(
-    response.results.bindings[0]
-  );
+  const editorDocument: EditorDocumentInput = objectify(bindings[0]);
   return EditorDocumentSchema.parse(editorDocument);
 }
 
 export async function findEditorDocumentOrFail(
   uri: string,
-  acceptMultiple?: boolean
+  assertUniquenessOf?: (keyof EditorDocument)[]
 ) {
-  const editorDocument = await findEditorDocument(uri, acceptMultiple);
+  const editorDocument = await findEditorDocument(uri, assertUniquenessOf);
   return expect(
     editorDocument,
     new AppError(

--- a/src/db/editor-document.ts
+++ b/src/db/editor-document.ts
@@ -17,7 +17,10 @@ import {
 import { Optional } from '../utils/types';
 import { expect } from '../utils/option';
 
-export async function findEditorDocument(uri: string) {
+export async function findEditorDocument(
+  uri: string,
+  acceptMultiple?: boolean
+) {
   const response = await query<EditorDocument>(/* sparql */ `
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -57,7 +60,7 @@ export async function findEditorDocument(uri: string) {
   if (!response.results.bindings.length) {
     return null;
   }
-  if (response.results.bindings.length > 1) {
+  if (!acceptMultiple && response.results.bindings.length > 1) {
     throw new AppError(
       StatusCodes.CONFLICT,
       `Expected to only find a single result when querying EditorDocument ${uri} `
@@ -69,8 +72,11 @@ export async function findEditorDocument(uri: string) {
   return EditorDocumentSchema.parse(editorDocument);
 }
 
-export async function findEditorDocumentOrFail(uri: string) {
-  const editorDocument = await findEditorDocument(uri);
+export async function findEditorDocumentOrFail(
+  uri: string,
+  acceptMultiple?: boolean
+) {
+  const editorDocument = await findEditorDocument(uri, acceptMultiple);
   return expect(
     editorDocument,
     new AppError(


### PR DESCRIPTION
~~This PR is a draft as it's not an ideal solution, but we can choose to merge it if we want to fast-track a solution to the problem.~~ I improved the API, but I'm still happy to hear comments or suggestions.

The query in question is only used for the `updated` timestamp. ~~Ideally we would~~ So we tweak the query API to ~~either only SELECT for fields we're interested in, or~~ specify which fields cannot be duplicates. More ideally, the data should never be in this state, so this is just a workaround.

Should fix: https://binnenland.atlassian.net/browse/GN-5928
PR to set updated-on: https://github.com/lblod/frontend-reglementaire-bijlage/pull/342

### Setup
It's unclear how the (destination) DB got into this state in the first place, but recreating it can either be done with a QA backup or by manually inserting a new `dct:title` triple for an `editor-document` that you want to import; it must be the latest of a document-container.

### How to test/reproduce
- Export a template from a source environment (e.g. dev or from a prod backup, etc), ensuring that the document-container is the one with the duplicate `dct:title` in the destination environment.
- Import that template into the destination environment (see setup).
- Without this fix, an error is shown. With this fix, the import works correctly and the imported version is now the latest version for the template in question.